### PR TITLE
add the ability for multiple cards to upload to different directories

### DIFF
--- a/etc/eyefiserver.conf
+++ b/etc/eyefiserver.conf
@@ -36,7 +36,8 @@ geotag_accuracy:140000
 # /home/myblog/pictures/%%Y-%%m-%%d
 # notice the double percent sign to escape % from ini interpolation
 
-upload_dir:/home/david/Pictures/eye-fi/%%Y-%%m
+upload_dirs_0:/home/david/Pictures/eye-fi/%%Y-%%m
+upload_dirs_1:/home/david/Pictures/eye-fi/%%Y-%%m
 
 # The UID of the user that you want to own the uploaded images (if commented out, ownership of files will not be changed)
 upload_uid:0

--- a/usr/local/bin/eyefiserver.py
+++ b/usr/local/bin/eyefiserver.py
@@ -678,7 +678,10 @@ class EyeFiRequestHandler(BaseHTTPRequestHandler):
                 timeoffset = time.timezone
             timezone = timeoffset / 60 / 60 * -1
             imageDate = datetime.fromtimestamp(member.mtime) - timedelta(hours=timezone)
-            uploadDir = imageDate.strftime(self.server.config.get('EyeFiServer','upload_dir'))
+
+            mac_to_uploaddir_map = self._get_mac_uploaddir_dict()
+            mac = handler.extractedElements["macaddress"]
+            uploadDir = imageDate.strftime(mac_to_uploaddir_map[mac])
             eyeFiLogger.debug("Creating folder " + uploadDir)
             if not os.path.isdir(uploadDir):
                 os.makedirs(uploadDir)
@@ -855,6 +858,21 @@ class EyeFiRequestHandler(BaseHTTPRequestHandler):
         doc.appendChild(SOAPElement)
 
         return doc.toxml(encoding="UTF-8")
+
+    def _get_mac_uploaddir_dict(self):
+        macs = {}
+        upload_dirs = {}
+        for key, value in self.server.config.items('EyeFiServer'):
+            if key.find('upload_dirs_') == 0:
+                index = int(key[12:])
+                upload_dirs[index] = value
+            elif key.find('mac_') == 0:
+                index = int(key[4:])
+                macs[index] = value
+        d = {}
+        for key in macs.keys():
+            d[macs[key]] = upload_dirs[key]
+        return d
 
     def _get_mac_uploadkey_dict(self):
         macs = {}


### PR DESCRIPTION
I have 2 eyefi cards, one for a camera, and one for a portable scanner. i don't want both cards to dump into the same directory, since I need to process the scans differently then the pics. I changes the format of the conf file a bit, to upload_dir is upload_dirs_0/1/2/3/etc to match the mac and upload_key. That's it. 

Tested on Mint17 and fedora 19.